### PR TITLE
modernize lua code

### DIFF
--- a/colors/rusty.lua
+++ b/colors/rusty.lua
@@ -1,0 +1,9 @@
+if vim.g.colors_name then
+	vim.cmd.hi("clear")
+end
+if vim.fn.exists("syntax_on") then
+	vim.cmd("syntax reset")
+end
+vim.g.colors_name = "rusty"
+
+require("rusty").apply()

--- a/colors/rusty.vim
+++ b/colors/rusty.vim
@@ -1,2 +1,0 @@
-" Dummy colorscheme file for Rusty
-lua require("rusty").apply()

--- a/lua/rusty/init.lua
+++ b/lua/rusty/init.lua
@@ -15,52 +15,52 @@ local config = {
 	italic_comments = true,  -- Enable/disable italic comments
 	underline_current_line = false,  -- Enable/disable underline for current line
 	colors = {
-		foreground = "c5c8c6",
-		background = "1d1f21",
-		selection = "373b41",
-		line = "282a2e",
-		comment = "969896",
-		red = "cc6666",
-		orange = "de935f",
-		yellow = "f0c674",
-		green = "b5bd68",
-		aqua = "8abeb7",
-		blue = "81a2be",
-		purple = "b294bb",
-		window = "4d5057",
+		foreground = "#c5c8c6",
+		background = "#1d1f21",
+		selection = "#373b41",
+		line = "#282a2e",
+		comment = "#969896",
+		red = "#cc6666",
+		orange = "#de935f",
+		yellow = "#f0c674",
+		green = "#b5bd68",
+		aqua = "#8abeb7",
+		blue = "#81a2be",
+		purple = "#b294bb",
+		window = "#4d5057",
 	}
 }
 
 local lualine = {
 	normal = {
-		a = { fg = "#" .. config.colors.background, bg = "#" .. config.colors.blue, gui = "bold" },
-		b = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.line },
-		c = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.background },
+		a = { fg = config.colors.background, bg = config.colors.blue, gui = "bold" },
+		b = { fg = config.colors.foreground, bg = config.colors.line },
+		c = { fg = config.colors.foreground, bg = config.colors.background },
 	},
 	insert = {
-		a = { fg = "#" .. config.colors.background, bg = "#" .. config.colors.green, gui = "bold" },
-		b = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.line },
-		c = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.background },
+		a = { fg = config.colors.background, bg = config.colors.green, gui = "bold" },
+		b = { fg = config.colors.foreground, bg = config.colors.line },
+		c = { fg = config.colors.foreground, bg = config.colors.background },
 	},
 	visual = {
-		a = { fg = "#" .. config.colors.background, bg = "#" .. config.colors.purple, gui = "bold" },
-		b = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.line },
-		c = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.background },
+		a = { fg = config.colors.background, bg = config.colors.purple, gui = "bold" },
+		b = { fg = config.colors.foreground, bg = config.colors.line },
+		c = { fg = config.colors.foreground, bg = config.colors.background },
 	},
 	replace = {
-		a = { fg = "#" .. config.colors.background, bg = "#" .. config.colors.red, gui = "bold" },
-		b = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.line },
-		c = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.background },
+		a = { fg = config.colors.background, bg = config.colors.red, gui = "bold" },
+		b = { fg = config.colors.foreground, bg = config.colors.line },
+		c = { fg = config.colors.foreground, bg = config.colors.background },
 	},
 	command = {
-		a = { fg = "#" .. config.colors.background, bg = "#" .. config.colors.orange, gui = "bold" },
-		b = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.line },
-		c = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.background },
+		a = { fg = config.colors.background, bg = config.colors.orange, gui = "bold" },
+		b = { fg = config.colors.foreground, bg = config.colors.line },
+		c = { fg = config.colors.foreground, bg = config.colors.background },
 	},
 	inactive = {
-		a = { fg = "#" .. config.colors.background, bg = "#" .. config.colors.line, gui = "bold" },
-		b = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.line },
-		c = { fg = "#" .. config.colors.foreground, bg = "#" .. config.colors.background },
+		a = { fg = config.colors.background, bg = config.colors.line, gui = "bold" },
+		b = { fg = config.colors.foreground, bg = config.colors.line },
+		c = { fg = config.colors.foreground, bg = config.colors.background },
 	},
 }
 
@@ -74,25 +74,22 @@ end
 
 -- Convert hex to cterm color
 local function hex_to_cterm(hex)
-	local r = tonumber(hex:sub(1, 2), 16)
-	local g = tonumber(hex:sub(3, 4), 16)
-	local b = tonumber(hex:sub(5, 6), 16)
-	return string.format("%d", (r * 36 + g * 6 + b) / 51)
+  if hex == "NONE" then return "NONE" end
+	local r = tonumber(hex:sub(2, 3), 16)
+	local g = tonumber(hex:sub(4, 5), 16)
+	local b = tonumber(hex:sub(6, 7), 16)
+	return math.floor((r * 36 + g * 6 + b) / 51)
 end
 
 -- Apply highlights for various groups
 local function apply_highlight(group, fg, bg, attr)
-	local cmd = "highlight " .. group
-	if fg then cmd = cmd .. " guifg=#" .. fg .. " ctermfg=" .. hex_to_cterm(fg) end
-	if bg then
-		if config.transparent and group == "Normal" then
-			cmd = cmd .. " guibg=NONE ctermbg=NONE"
-		else
-			cmd = cmd .. " guibg=#" .. bg .. " ctermbg=" .. hex_to_cterm(bg)
-		end
-	end
-	if attr then cmd = cmd .. " gui=" .. attr .. " cterm=" .. attr end
-	vim.cmd(cmd)
+  fg = fg and fg or "NONE"
+  bg = bg and bg or "NONE"
+  attr = attr and attr or {}
+  vim.api.nvim_set_hl(0, group, vim.tbl_extend("force", {
+    fg = fg, ctermfg = hex_to_cterm(fg),
+    bg = bg, ctermbg = hex_to_cterm(bg),
+  }, attr))
 end
 
 -- Apply all the necessary highlights for Vim
@@ -100,16 +97,16 @@ function M.apply()
 	local c = config.colors
 
 	-- Basic highlights
-	apply_highlight("Normal", c.foreground, c.background)
+	apply_highlight("Normal", c.foreground, config.transparent and nil or c.background)
 	apply_highlight("NormalFloat", c.foreground, c.background)
 	apply_highlight("LineNr", c.selection, nil)
 	apply_highlight("NonText", c.selection, nil)
 	apply_highlight("SpecialKey", c.selection, nil)
 	apply_highlight("Search", c.background, c.yellow)
-	apply_highlight("TabLine", c.foreground, c.background, "reverse")
+	apply_highlight("TabLine", c.foreground, c.background, { reverse = true })
 	apply_highlight("StatusLine", c.yellow, c.background, nil)
-	apply_highlight("StatusLineNC", c.window, c.foreground, "reverse")
-	apply_highlight("VertSplit", c.window, c.window, "none")
+	apply_highlight("StatusLineNC", c.window, c.foreground, { reverse = true })
+	apply_highlight("VertSplit", c.window, c.window, nil)
 	apply_highlight("Visual", nil, c.selection)
 	apply_highlight("Directory", c.blue, nil)
 	apply_highlight("ModeMsg", c.green, nil)
@@ -119,19 +116,19 @@ function M.apply()
 	apply_highlight("MatchParen", nil, c.selection)
 	apply_highlight("Folded", c.comment, c.background)
 	apply_highlight("FoldColumn", nil, c.background)
-	apply_highlight("CursorLine", nil, config.underline_current_line and c.line or nil, "none")
-	apply_highlight("CursorColumn", nil, nil, "none")
-	apply_highlight("PMenu", c.foreground, c.selection, "none")
-	apply_highlight("PMenuSel", c.foreground, c.selection, "reverse")
-	apply_highlight("SignColumn", nil, nil, "none")
-	apply_highlight("ColorColumn", nil, nil, "none")
+	apply_highlight("CursorLine", nil, config.underline_current_line and c.line or nil, nil)
+	apply_highlight("CursorColumn", nil, nil, nil)
+	apply_highlight("PMenu", c.foreground, c.selection, nil)
+	apply_highlight("PMenuSel", c.foreground, c.selection, { reverse = true })
+	apply_highlight("SignColumn", nil, nil, nil)
+	apply_highlight("ColorColumn", nil, nil, nil)
 
 	-- Syntax highlights
 	apply_highlight("Type", c.orange, nil)
-	apply_highlight("Comment", c.comment, nil, config.italic_comments and "italic" or nil)
+	apply_highlight("Comment", c.comment, nil, config.italic_comments and { italic = true } or nil)
 	apply_highlight("Todo", c.comment, c.background)
 	apply_highlight("Title", c.comment, nil)
-	apply_highlight("Identifier", c.purple, nil, "none")
+	apply_highlight("Identifier", c.purple, nil, nil)
 	apply_highlight("Statement", c.purple, nil)
 	apply_highlight("Function", c.foreground, nil)
 	apply_highlight("Constant", c.orange, nil)
@@ -139,24 +136,24 @@ function M.apply()
 	apply_highlight("String", c.green, nil)
 	apply_highlight("Special", c.foreground, nil)
 	apply_highlight("PreProc", c.orange, nil)
-	apply_highlight("Structure", c.foreground, nil, "none")
+	apply_highlight("Structure", c.foreground, nil, nil)
 	apply_highlight("Include", c.aqua, nil)
 	apply_highlight("Operator", c.foreground, nil)
 
 	-- Vim-specific highlights
-	apply_highlight("vimCommand", c.red, nil, "none")
-	apply_highlight("@namespace", c.foreground, nil, "none")
-	apply_highlight("@function", c.aqua, nil, "none")
+	apply_highlight("vimCommand", c.red, nil, nil)
+	apply_highlight("@namespace", c.foreground, nil, nil)
+	apply_highlight("@function", c.aqua, nil, nil)
 
 	-- LSP highlights
-	apply_highlight("@lsp.type.function", c.aqua, nil, "none")
-	apply_highlight("@lsp.type.variable", c.foreground, nil, "none")
-	apply_highlight("@lsp.type.struct", c.orange, nil, "none")
-	apply_highlight("@lsp.type.namespace", c.foreground, nil, "none")
-	apply_highlight("@lsp.type.enumMember", c.foreground, nil, "none")
+	apply_highlight("@lsp.type.function", c.aqua, nil, nil)
+	apply_highlight("@lsp.type.variable", c.foreground, nil, nil)
+	apply_highlight("@lsp.type.struct", c.orange, nil, nil)
+	apply_highlight("@lsp.type.namespace", c.foreground, nil, nil)
+	apply_highlight("@lsp.type.enumMember", c.foreground, nil, nil)
 
 	-- Diff highlights
-	local diffbackground = "494e56"
+	local diffbackground = "#494e56"
 	apply_highlight("diffAdded", c.green, nil)
 	apply_highlight("diffRemoved", c.red, nil)
 	apply_highlight("DiffAdd", c.green, diffbackground)
@@ -165,10 +162,10 @@ function M.apply()
 	apply_highlight("DiffText", diffbackground, c.orange)
 
 	-- ShowMarks highlights
-	apply_highlight("ShowMarksHLl", c.orange, c.background, "none")
-	apply_highlight("ShowMarksHLo", c.purple, c.background, "none")
-	apply_highlight("ShowMarksHLu", c.yellow, c.background, "none")
-	apply_highlight("ShowMarksHLm", c.aqua, c.background, "none")
+	apply_highlight("ShowMarksHLl", c.orange, c.background, nil)
+	apply_highlight("ShowMarksHLo", c.purple, c.background, nil)
+	apply_highlight("ShowMarksHLu", c.yellow, c.background, nil)
+	apply_highlight("ShowMarksHLm", c.aqua, c.background, nil)
 end
 
 return M


### PR DESCRIPTION
Added some boilerplate in `colors/rusty.lua` to account for the colorscheme name and resetting highlight and syntax.

Changed the way the `apply_highlight` function works: instead of making command string, I directly call `vim.api.nvim_set_hl`.

Changed the way the colors are represented. Now they have `#` in their string representations, which makes it easier if you have something like `mini.hipatterns`. Adjusted the code for converting to hex and the rest.